### PR TITLE
Fix formatting in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
     "friendsofphp/php-cs-fixer": "^3.22"
   },
   "require": {
-    "pkp/app-implementation": "^3.4",
+    "pkp/app-implementation": "^3.4"
   }
 }


### PR DESCRIPTION
Hallo @stutzmann72 

Habe festgestellt, dass unser packagist repo im build step motzt, weil da ein komma ist beim letzten Eintrag in der liste.
Habe das entfernt und erlaube mir die Änderung zu force mergen, da wir ansonsten keine neuen packages mehr deployen können.

